### PR TITLE
bump to 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jquery.version>1.9.0</jquery.version>
+        <jquery.version>1.9.1</jquery.version>
         <downloadUrl>https://ajax.googleapis.com/ajax/libs/jquery/${jquery.version}</downloadUrl>
         <destinationDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${jquery.version}</destinationDir>
     </properties>


### PR DESCRIPTION
bump jquery to 1.9.1
- maven-release-plugin upgrade to 2.4
- allow wagon behind proxy
