### PR TITLE
Updated to 1.10.2 and added source map

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>jquery</artifactId>
-    <version>2.0.4-SNAPSHOT</version>
+    <version>1.10.2-SNAPSHOT</version>
     <name>jquery</name>
     <description>WebJar for jQuery</description>
     <url>http://webjars.org</url>
@@ -41,7 +41,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jquery.version>2.0.3</jquery.version>
+        <jquery.version>1.10.2</jquery.version>
         <downloadUrl>http://code.jquery.com</downloadUrl>
         <destinationDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${jquery.version}</destinationDir>
     </properties>
@@ -71,6 +71,16 @@
                             <url>${downloadUrl}</url>
                             <fromFile>jquery-${jquery.version}.min.js</fromFile>
                             <toFile>${destinationDir}/jquery.min.js</toFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>download-source-map</id>
+                        <phase>process-resources</phase>
+                        <goals><goal>download-single</goal></goals>
+                        <configuration>
+                            <url>${downloadUrl}</url>
+                            <fromFile>jquery-${jquery.version}.min.map</fromFile>
+                            <toFile>${destinationDir}/jquery.min.map</toFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Source maps also have a versionable URL, so it will work for 2.x as well.
