### PR TITLE
jquery.min.map should contain version number in its name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                         <configuration>
                             <url>${downloadUrl}</url>
                             <fromFile>jquery-${jquery.version}.min.map</fromFile>
-                            <toFile>${destinationDir}/jquery.min.map</toFile>
+                            <toFile>${destinationDir}/jquery-${jquery.version}.min.map</toFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This file is referenced by jquery.js and the version number is used in the file name. 
