### PR TITLE
Provided intial OSGi support for WebJars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
     </developers>
 
     <properties>
+		<bnd.bundle.version>3.3.1.2-SNAPSHOT</bnd.bundle.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <downloadUrl>https://cdnjs.cloudflare.com/ajax/libs/jquery/${version.unrevise}</downloadUrl>
         <destinationDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</destinationDir>
@@ -108,6 +109,46 @@
                     </execution>
                 </executions>
             </plugin>
+			
+			<plugin>
+				<groupId>biz.aQute.bnd</groupId>
+				<artifactId>bnd-maven-plugin</artifactId>
+				<configuration>
+					<bnd>
+					<![CDATA[
+						Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
+						Bundle-Version:	 ${bnd.bundle.version}
+						Bundle-Description: ${project.description}
+						-resourceonly:true
+						WebJars-Resource:\
+							/META-INF/resources/webjars/${project.artifactId}/${project.version},\
+							/webjars-requirejs.js
+						Provide-Capability: ${project.groupId};${project.artifactId}:List<String>=${project.version}
+					]]>
+					</bnd>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>bnd-process</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<!-- Required to make the maven-jar-plugin pick up the bnd --> 
+            <!-- generated manifest. Also avoid packaging empty Jars -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
+				<configuration>
+					<archive>
+						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+					</archive>
+					<skipIfEmpty>true</skipIfEmpty>
+				</configuration>
+			</plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
I've added the bnd-maven-plugin to generate the necessary Manifest content, like
* Bundle-Version
* Bundle-Symbolic-Name
* Require / Provide-Capability
* WebJars-Resource

WebJars-Resource can be used in an OSGi environment to find WebJar bundles with a `BundleTracker` and register their resources at a `HttpService`. 

Require-Capability is redeclaring the dependencies that are also used by maven, but in a format that the OSGi resolver can use to automatically resolve those dependencies.

The Bundle-Version has to be set manually if the `${project.version}` is not OSGi compatible, e.g. a version like this: 1.2.3-2-SNAPSHOT. Bnd would ignore the "-2-" part and create the version like this: 1.2.3.SNAPSHOT, where probably something like 1.2.3.2-SNAPSHOT would be preferred. Therefore I had to create a new property `bnd.bundle.version` that is set to 1.2.3.2-SNAPSHOT to achieve this.